### PR TITLE
fix(null): handle nullable postcode and state ZNA

### DIFF
--- a/src/Model/AbnResponse.php
+++ b/src/Model/AbnResponse.php
@@ -30,12 +30,10 @@ final class AbnResponse extends AbstractResponse
     public \DateTimeImmutable $addressDate;
 
     #[SerializedName('AddressPostcode')]
-    #[NotBlank]
-    public string $addressPostcode;
+    public ?string $addressPostcode;
 
     #[SerializedName('AddressState')]
-    #[NotBlank]
-    public string $addressState;
+    public ?string $addressState;
 
     /**
      * @var string[]

--- a/tests/Model/AbnResponseTest.php
+++ b/tests/Model/AbnResponseTest.php
@@ -48,11 +48,11 @@ final class AbnResponseTest extends BaseModelTest
         $fields['Gst'] = null;
         yield 'no gst' => [$fields];
 
-        $fields        = MockAbnResponse::valid();
+        $fields                 = MockAbnResponse::valid();
         $fields['AddressState'] = null;
         yield 'no address state' => [$fields];
 
-        $fields        = MockAbnResponse::valid();
+        $fields                    = MockAbnResponse::valid();
         $fields['AddressPostcode'] = null;
         yield 'no AddressPostcode' => [$fields];
     }

--- a/tests/Model/AbnResponseTest.php
+++ b/tests/Model/AbnResponseTest.php
@@ -47,6 +47,14 @@ final class AbnResponseTest extends BaseModelTest
         $fields        = MockAbnResponse::valid();
         $fields['Gst'] = null;
         yield 'no gst' => [$fields];
+
+        $fields        = MockAbnResponse::valid();
+        $fields['AddressState'] = null;
+        yield 'no address state' => [$fields];
+
+        $fields        = MockAbnResponse::valid();
+        $fields['AddressPostcode'] = null;
+        yield 'no AddressPostcode' => [$fields];
     }
 
     /**
@@ -85,8 +93,6 @@ final class AbnResponseTest extends BaseModelTest
             'AbnStatus',
             'AbnStatusEffectiveFrom',
             'AddressDate',
-            'AddressPostcode',
-            'AddressState',
             'EntityName',
             'EntityTypeCode',
             'EntityTypeName',


### PR DESCRIPTION
Some record in the ABR, particularly New Zealand entities (in Australia?!) appear to not have a postcode/state, so this PR makes them nullable.

This will need a BC break