### PR TITLE
fix(abr): allow empty string not null

### DIFF
--- a/src/Model/AbnResponse.php
+++ b/src/Model/AbnResponse.php
@@ -30,10 +30,10 @@ final class AbnResponse extends AbstractResponse
     public \DateTimeImmutable $addressDate;
 
     #[SerializedName('AddressPostcode')]
-    public ?string $addressPostcode;
+    public string $addressPostcode;
 
     #[SerializedName('AddressState')]
-    public ?string $addressState;
+    public string $addressState;
 
     /**
      * @var string[]

--- a/tests/Model/AbnResponseTest.php
+++ b/tests/Model/AbnResponseTest.php
@@ -49,12 +49,12 @@ final class AbnResponseTest extends BaseModelTest
         yield 'no gst' => [$fields];
 
         $fields                 = MockAbnResponse::valid();
-        $fields['AddressState'] = null;
-        yield 'no address state' => [$fields];
+        $fields['AddressState'] = '';
+        yield 'empty string for address state' => [$fields];
 
         $fields                    = MockAbnResponse::valid();
-        $fields['AddressPostcode'] = null;
-        yield 'no AddressPostcode' => [$fields];
+        $fields['AddressPostcode'] = '';
+        yield 'empty string for address postcode' => [$fields];
     }
 
     /**


### PR DESCRIPTION
Switch to just allow empty string instead - API appears to always return empty string instead of null 