### PR TITLE
feat(formatter): add ABN formatter function

### DIFF
--- a/src/AbnFormatter.php
+++ b/src/AbnFormatter.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyra\AbnLookup;
+
+final class AbnFormatter
+{
+    public static function format(string $abn): string
+    {
+        return \sprintf(
+            '%s %s %s %s',
+            \mb_substr($abn, 0, 2),
+            \mb_substr($abn, 2, 3),
+            \mb_substr($abn, 5, 3),
+            \mb_substr($abn, 8, 3)
+        );
+    }
+}

--- a/tests/Unit/AbnFormatterTest.php
+++ b/tests/Unit/AbnFormatterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyra\Tests\AbnLookup\Unit;
+
+use Hyra\AbnLookup\AbnFormatter;
+use PHPUnit\Framework\TestCase;
+
+class AbnFormatterTest extends TestCase
+{
+    public function testFormatter(): void
+    {
+        $abn          = '30616935623';
+        $formattedAbn = '30 616 935 623';
+
+        $result = AbnFormatter::format($abn);
+
+        static::assertSame($result, $formattedAbn);
+    }
+}


### PR DESCRIPTION
Function takes an ABN string and returns it with spaces.

e.g. `AbnFormatter::format('30616935623') -> '30 616 935 623'`